### PR TITLE
feat: add seller metrics retrieval with new API endpoint

### DIFF
--- a/services/main/src/main/java/org/retrade/main/controller/SellerController.java
+++ b/services/main/src/main/java/org/retrade/main/controller/SellerController.java
@@ -7,9 +7,9 @@ import org.retrade.common.model.dto.response.ResponseObject;
 import org.retrade.main.model.dto.request.ApproveSellerRequest;
 import org.retrade.main.model.dto.request.SellerRegisterRequest;
 import org.retrade.main.model.dto.request.SellerUpdateRequest;
+import org.retrade.main.model.dto.response.SellerBaseMetricResponse;
 import org.retrade.main.model.dto.response.SellerBaseResponse;
 import org.retrade.main.model.dto.response.SellerRegisterResponse;
-import org.retrade.main.model.dto.response.TopSellersResponse;
 import org.retrade.main.service.FileService;
 import org.retrade.main.service.OrderService;
 import org.retrade.main.service.SellerService;
@@ -142,6 +142,17 @@ public class SellerController {
                 .success(true)
                 .code("SUCCESS")
                 .messages("ban seller with" + id + " successfully")
+                .build());
+    }
+
+    @GetMapping("{id}/metric")
+    public ResponseEntity<ResponseObject<SellerBaseMetricResponse>> getSellerStats (String id) {
+        var metrics = sellerService.getSellerBaseMetric(id);
+        return ResponseEntity.ok(new ResponseObject.Builder<SellerBaseMetricResponse>()
+                .success(true)
+                .code("SUCCESS")
+                .content(metrics)
+                .messages("Get Seller Stats Successfully")
                 .build());
     }
 }

--- a/services/main/src/main/java/org/retrade/main/controller/SellerController.java
+++ b/services/main/src/main/java/org/retrade/main/controller/SellerController.java
@@ -146,7 +146,7 @@ public class SellerController {
     }
 
     @GetMapping("{id}/metric")
-    public ResponseEntity<ResponseObject<SellerBaseMetricResponse>> getSellerStats (String id) {
+    public ResponseEntity<ResponseObject<SellerBaseMetricResponse>> getSellerStats (@PathVariable String id) {
         var metrics = sellerService.getSellerBaseMetric(id);
         return ResponseEntity.ok(new ResponseObject.Builder<SellerBaseMetricResponse>()
                 .success(true)

--- a/services/main/src/main/java/org/retrade/main/model/dto/response/SellerBaseMetricResponse.java
+++ b/services/main/src/main/java/org/retrade/main/model/dto/response/SellerBaseMetricResponse.java
@@ -1,0 +1,17 @@
+package org.retrade.main.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SellerBaseMetricResponse {
+    private Long productQuantity;
+    private Double avgVote;
+    private Long totalOrder;
+    private Long totalOrderSold;
+}

--- a/services/main/src/main/java/org/retrade/main/repository/jpa/OrderComboRepository.java
+++ b/services/main/src/main/java/org/retrade/main/repository/jpa/OrderComboRepository.java
@@ -94,4 +94,8 @@ public interface OrderComboRepository extends BaseJpaRepository<OrderComboEntity
         ORDER BY o.createdDate DESC
     """)
     List<RecentOrderProjection> getRecentOrders(@Param("seller") SellerEntity seller, Pageable pageable);
+
+    long countBySellerAndOrderStatus_Code(SellerEntity seller, String code);
+
+    long countBySeller(@NonNull SellerEntity seller);
 }

--- a/services/main/src/main/java/org/retrade/main/service/SellerService.java
+++ b/services/main/src/main/java/org/retrade/main/service/SellerService.java
@@ -5,6 +5,7 @@ import org.retrade.common.model.dto.response.PaginationWrapper;
 import org.retrade.main.model.dto.request.ApproveSellerRequest;
 import org.retrade.main.model.dto.request.SellerRegisterRequest;
 import org.retrade.main.model.dto.request.SellerUpdateRequest;
+import org.retrade.main.model.dto.response.SellerBaseMetricResponse;
 import org.retrade.main.model.dto.response.SellerBaseResponse;
 import org.retrade.main.model.dto.response.SellerRegisterResponse;
 import org.retrade.main.model.dto.response.TopSellersResponse;
@@ -18,6 +19,8 @@ public interface SellerService {
     SellerRegisterResponse createSeller(SellerRegisterRequest request);
 
     void approveSeller(ApproveSellerRequest request);
+
+    SellerBaseMetricResponse getSellerBaseMetric(String sellerId);
 
     PaginationWrapper<List<SellerBaseResponse>> getSellers (QueryWrapper wrapper);
 


### PR DESCRIPTION
- Introduced `getSellerBaseMetric` method in `SellerServiceImpl` to fetch seller statistics, including product count, average rating, and order metrics.
- Added `SellerBaseMetricResponse` DTO for encapsulating seller metric data.
- Created new API endpoint `GET /{id}/metric` in `SellerController` for fetching seller metrics.
- Updated repositories (`ProductRepository`, `OrderComboRepository`) with methods for querying seller-related statistics.