### PR TITLE
feat: add seller product metrics and filter APIs

### DIFF
--- a/.docker/compose.yaml
+++ b/.docker/compose.yaml
@@ -95,6 +95,8 @@ services:
       ORIGIN_ALLOWS: ${ORIGIN_ALLOWS}
       BASE_HOST: ${BASE_HOST}
       FRONTEND_URL: ${FRONTEND_URL}
+      MAIN_SERVICE_GRPC_HOST: main-service
+      MAIN_SERVICE_GRPC_PORT: 9080
       SWAGGER_CONTEXT_PATH: /api/feedback-notification/v1
       PORT: 8080
       TZ: Asia/Ho_Chi_Minh

--- a/packages/proto/authentication.proto
+++ b/packages/proto/authentication.proto
@@ -16,6 +16,10 @@ message TokenRequest {
     TokenType type = 2;
 }
 
+message UsernameRequest {
+    string username = 1;
+}
+
 message AccountIdRequest {
     string id = 1;
 }
@@ -27,6 +31,15 @@ message UserTokenInfo {
     bool is_active = 4;
     bool is_verified = 5;
     TokenType type = 6;
+}
+
+message AccountInfo {
+    string account_id = 1;
+    repeated string roles = 2;
+    string username = 3;
+    bool is_active = 4;
+    bool is_verified = 5;
+    bool changed_username = 6;
 }
 
 message CustomerDetailInfo {
@@ -62,6 +75,12 @@ message VerifyTokenResponse {
     repeated string error_messages = 3;
 }
 
+message GetAccountResponse {
+    bool is_valid = 1;
+    AccountInfo user_info = 2;
+    repeated string error_messages = 3;
+}
+
 message GetCustomerProfileResponse {
     bool is_valid = 1;
     CustomerDetailInfo user_info = 2;
@@ -81,4 +100,5 @@ service GrpcTokenService {
     rpc GetSellerProfileById (AccountIdRequest) returns (GetSellerProfileResponse);
     rpc GetSellerProfileBySellerId (AccountIdRequest) returns (GetSellerProfileResponse);
     rpc GetCustomerProfileByCustomerId (AccountIdRequest) returns (GetCustomerProfileResponse);
+    rpc GetUserAccountByUserName(UsernameRequest) returns (GetAccountResponse);
 }

--- a/services/feedback-notification/pom.xml
+++ b/services/feedback-notification/pom.xml
@@ -23,15 +23,15 @@
 					<groupId>org.springframework.boot</groupId>
 					<artifactId>spring-boot-starter-data-mongodb</artifactId>
 				</exclusion>
-				<exclusion>
-					<groupId>org.springframework.boot</groupId>
-					<artifactId>spring-boot-starter-data-jpa</artifactId>
-				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-websocket</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>

--- a/services/feedback-notification/pom.xml
+++ b/services/feedback-notification/pom.xml
@@ -30,6 +30,23 @@
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-websocket</artifactId>
 		</dependency>

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/client/TokenServiceClient.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/client/TokenServiceClient.java
@@ -32,15 +32,9 @@ public class TokenServiceClient {
                 .build());
     }
 
-    public GetSellerProfileResponse getSellerProfileByToken(String token, TokenType tokenType) {
-        return blockingStub.getSellerProfile(TokenRequest.newBuilder()
-                .setToken(token)
-                .setType(tokenType)
-                .build());
-    }
-
-    public GetSellerProfileResponse getSellerProfileBySellerId(String id) {
-        return blockingStub.getSellerProfileBySellerId(AccountIdRequest.newBuilder().setId(id)
+    public GetAccountResponse getAccountInfoByUsername(String username) {
+        return blockingStub.getUserAccountByUserName(UsernameRequest.newBuilder()
+                        .setUsername(username)
                 .build());
     }
 

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/client/TokenServiceClient.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/client/TokenServiceClient.java
@@ -1,0 +1,68 @@
+package org.retrade.feedback_notification.client;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.retrade.proto.authentication.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TokenServiceClient {
+    @Value("${grpc.client.main-service.host:localhost}")
+    private String mainServiceHost;
+
+    @Value("${grpc.client.main-service.port:9080}")
+    private int mainServicePort;
+
+    private ManagedChannel channel;
+    private GrpcTokenServiceGrpc.GrpcTokenServiceBlockingStub blockingStub;
+
+    public VerifyTokenResponse verifyToken(String token, TokenType tokenType) {
+        return blockingStub.verifyToken(TokenRequest.newBuilder()
+                .setToken(token)
+                .setType(tokenType)
+                .build());
+    }
+
+    public GetSellerProfileResponse getSellerProfileByToken(String token, TokenType tokenType) {
+        return blockingStub.getSellerProfile(TokenRequest.newBuilder()
+                .setToken(token)
+                .setType(tokenType)
+                .build());
+    }
+
+    public GetSellerProfileResponse getSellerProfileBySellerId(String id) {
+        return blockingStub.getSellerProfileBySellerId(AccountIdRequest.newBuilder().setId(id)
+                .build());
+    }
+
+    @PostConstruct
+    public void init() {
+        channel = ManagedChannelBuilder.forAddress(mainServiceHost, mainServicePort)
+                .usePlaintext()
+                .build();
+        blockingStub = GrpcTokenServiceGrpc.newBlockingStub(channel);
+        log.info("Main gRPC client initialized for {}:{}", mainServiceHost, mainServicePort);
+    }
+
+    @PreDestroy
+    public void destroy() {
+        if (channel != null) {
+            try {
+                channel.shutdown().awaitTermination(5, TimeUnit.SECONDS);
+                log.info("Main gRPC client channel closed");
+            } catch (InterruptedException e) {
+                log.warn("Failed to close gRPC channel gracefully", e);
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/common/FeedbackNotificationApplicationConfig.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/common/FeedbackNotificationApplicationConfig.java
@@ -1,4 +1,4 @@
-package org.retrade.feedback_notification.config;
+package org.retrade.feedback_notification.config.common;
 
 import org.springframework.context.annotation.Configuration;
 

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/common/HostConfig.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/common/HostConfig.java
@@ -1,4 +1,4 @@
-package org.retrade.feedback_notification.config;
+package org.retrade.feedback_notification.config.common;
 
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/common/RabbitMQConfig.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/common/RabbitMQConfig.java
@@ -1,4 +1,4 @@
-package org.retrade.feedback_notification.config;
+package org.retrade.feedback_notification.config.common;
 
 import org.springframework.amqp.core.AcknowledgeMode;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
@@ -16,23 +16,9 @@ import org.springframework.retry.interceptor.RetryOperationsInterceptor;
 @Configuration
 @EnableRabbit
 public class RabbitMQConfig {
-
-    public static final String NOTIFICATION_EXCHANGE = "notification.exchange";
-    public static final String NOTIFICATION_RETRY_EXCHANGE = "notification.dlx.exchange";
-    public static final String REGISTRATION_EXCHANGE = "registration.exchange";
-    public static final String REGISTRATION_RETRY_EXCHANGE = "registration.dlx.exchange";
-
     public static final String EMAIL_NOTIFICATION_QUEUE = "email.notification.queue";
-    public static final String EMAIL_RETRY_QUEUE = "email.dlx.queue";
     public static final String USER_REGISTRATION_QUEUE = "user.registration.queue";
-    public static final String USER_REGISTRATION_RETRY_QUEUE = "user.registration.dlx.queue";
     public static final String DEAD_LETTER_QUEUE = "dead.letter.queue";
-
-    public static final String EMAIL_NOTIFICATION_ROUTING_KEY = "email.notification";
-    public static final String EMAIL_RETRY_ROUTING_KEY = "email.retry";
-    public static final String USER_REGISTRATION_ROUTING_KEY = "user.registration";
-    public static final String USER_REGISTRATION_RETRY_ROUTING_KEY = "user.registration.retry";
-    public static final String DEAD_LETTER_ROUTING_KEY = "dead.letter";
 
     @Bean
     public MessageConverter jsonMessageConverter() {

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/common/SwaggerConfig.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/common/SwaggerConfig.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import lombok.RequiredArgsConstructor;
+import org.retrade.feedback_notification.config.security.HostConfig;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/common/SwaggerConfig.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/common/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package org.retrade.feedback_notification.config;
+package org.retrade.feedback_notification.config.common;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/security/CorsConfig.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/security/CorsConfig.java
@@ -1,6 +1,7 @@
-package org.retrade.feedback_notification.config;
+package org.retrade.feedback_notification.config.security;
 
 import lombok.RequiredArgsConstructor;
+import org.retrade.feedback_notification.config.common.HostConfig;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/security/CorsConfig.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/security/CorsConfig.java
@@ -1,7 +1,6 @@
 package org.retrade.feedback_notification.config.security;
 
 import lombok.RequiredArgsConstructor;
-import org.retrade.feedback_notification.config.common.HostConfig;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/security/HostConfig.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/security/HostConfig.java
@@ -1,4 +1,4 @@
-package org.retrade.feedback_notification.config.common;
+package org.retrade.feedback_notification.config.security;
 
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -12,4 +12,5 @@ public class HostConfig {
     private String baseHost;
     private String frontEnd;
     private String swaggerContextPath;
+    private Boolean developMode;
 }

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/security/JwtConfig.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/security/JwtConfig.java
@@ -1,0 +1,19 @@
+package org.retrade.feedback_notification.config.security;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+@Component
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "security.token.jwt")
+public class JwtConfig {
+    private JwtConfigValue accessToken;
+    @Data
+    public static class JwtConfigValue {
+        private String key;
+        private long maxAge;
+    }
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/security/SecurityConfig.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/security/SecurityConfig.java
@@ -1,6 +1,9 @@
 package org.retrade.feedback_notification.config.security;
 
 import lombok.RequiredArgsConstructor;
+import org.retrade.feedback_notification.security.CustomAuthenticationEntryPoint;
+import org.retrade.feedback_notification.security.JwtAuthenticationFilter;
+import org.retrade.feedback_notification.security.JwtCookieAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -9,6 +12,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -16,6 +20,9 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final CorsConfig corsConfig;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtCookieAuthenticationFilter jwtCookieAuthenticationFilter;
     @Bean
     SecurityFilterChain authenticationFilterChain (HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable);
@@ -25,9 +32,11 @@ public class SecurityConfig {
                 .requestMatchers("/files/**").permitAll()
                 .anyRequest().authenticated());
         http.exceptionHandling(exception -> {
-//            exception.authenticationEntryPoint(customAuthenticationEntryPoint);
+            exception.authenticationEntryPoint(customAuthenticationEntryPoint);
         });
-        http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterAfter(this.jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(this.jwtCookieAuthenticationFilter, JwtAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/security/SecurityConfig.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/security/SecurityConfig.java
@@ -1,0 +1,33 @@
+package org.retrade.feedback_notification.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true, jsr250Enabled = true, prePostEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final CorsConfig corsConfig;
+    @Bean
+    SecurityFilterChain authenticationFilterChain (HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable);
+        http.cors(cors -> cors.configurationSource(corsConfig.corsConfigurationSource()));
+        http.authorizeHttpRequests((auth) -> auth.requestMatchers("/api-docs/**", "/swagger-ui/**", "/actuator/health")
+                .permitAll()
+                .requestMatchers("/files/**").permitAll()
+                .anyRequest().authenticated());
+        http.exceptionHandling(exception -> {
+//            exception.authenticationEntryPoint(customAuthenticationEntryPoint);
+        });
+        http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return http.build();
+    }
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/security/SecurityConfig.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/security/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
     SecurityFilterChain authenticationFilterChain (HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable);
         http.cors(cors -> cors.configurationSource(corsConfig.corsConfigurationSource()));
-        http.authorizeHttpRequests((auth) -> auth.requestMatchers("/api-docs/**", "/swagger-ui/**", "/actuator/health")
+        http.authorizeHttpRequests((auth) -> auth.requestMatchers("/api-docs/**", "/ws", "/swagger-ui/**", "/actuator/health")
                 .permitAll()
                 .requestMatchers("/files/**").permitAll()
                 .anyRequest().authenticated());

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/socket/SocketConfig.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/socket/SocketConfig.java
@@ -1,0 +1,23 @@
+package org.retrade.feedback_notification.config.socket;
+
+import lombok.NonNull;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class SocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void configureMessageBroker(@NonNull MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/user");
+        config.setApplicationDestinationPrefixes("/user");
+    }
+
+    @Override
+    public void registerStompEndpoints(@NonNull StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOrigins("*");
+    }
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/socket/SocketConfig.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/config/socket/SocketConfig.java
@@ -12,8 +12,9 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class SocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureMessageBroker(@NonNull MessageBrokerRegistry config) {
-        config.enableSimpleBroker("/user");
-        config.setApplicationDestinationPrefixes("/user");
+        config.enableSimpleBroker("/queue", "/topic");
+        config.setApplicationDestinationPrefixes("/app");
+        config.setUserDestinationPrefix("/user");
     }
 
     @Override

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/controller/NotificationController.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/controller/NotificationController.java
@@ -1,0 +1,39 @@
+package org.retrade.feedback_notification.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.retrade.common.model.dto.request.QueryWrapper;
+import org.retrade.common.model.dto.response.ResponseObject;
+import org.retrade.feedback_notification.model.dto.NotificationResponse;
+import org.retrade.feedback_notification.service.NotificationService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @GetMapping("/me")
+    public ResponseEntity<ResponseObject<List<NotificationResponse>>> getUserNotification(@PageableDefault Pageable pageable, @RequestParam(required = false, name = "q") String query) {
+        var notifications = notificationService.getNotifications(QueryWrapper.builder()
+                        .wrapSort(pageable)
+                        .search(query)
+                .build());
+        return ResponseEntity.ok(
+          new ResponseObject.Builder<List<NotificationResponse>>()
+                  .success(true)
+                  .code("SUCCESS")
+                  .unwrapPaginationWrapper(notifications)
+                  .messages("Notification retrieved successfully")
+                  .build()
+        );
+    }
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/controller/NotificationController.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/controller/NotificationController.java
@@ -3,6 +3,7 @@ package org.retrade.feedback_notification.controller;
 import lombok.RequiredArgsConstructor;
 import org.retrade.common.model.dto.request.QueryWrapper;
 import org.retrade.common.model.dto.response.ResponseObject;
+import org.retrade.feedback_notification.model.dto.NotificationRequest;
 import org.retrade.feedback_notification.model.dto.NotificationResponse;
 import org.retrade.feedback_notification.service.NotificationService;
 import org.springframework.data.domain.Pageable;
@@ -34,6 +35,19 @@ public class NotificationController {
         );
     }
 
+    @PostMapping
+    public ResponseEntity<ResponseObject<NotificationResponse>> makeNotifications(@RequestBody NotificationRequest notificationResponse) {
+        var notification = notificationService.makeNotification(notificationResponse);
+        return ResponseEntity.ok(
+                new ResponseObject.Builder<NotificationResponse>()
+                        .success(true)
+                        .code("SUCCESS")
+                        .content(notification)
+                        .messages("Notification init successfully")
+                        .build()
+        );
+    }
+
     @PatchMapping("{id}/read")
     public ResponseEntity<ResponseObject<Void>> markAsRead(@PathVariable String id) {
         notificationService.markAsRead(id);
@@ -42,6 +56,18 @@ public class NotificationController {
                         .success(true)
                         .code("SUCCESS")
                         .messages("Notification mark successfully")
+                        .build()
+        );
+    }
+
+    @PostMapping("test")
+    public ResponseEntity<ResponseObject<Void>> testNotification () {
+        notificationService.testGlobalNotification();
+        return ResponseEntity.ok(
+                new ResponseObject.Builder<Void>()
+                        .success(true)
+                        .code("SUCCESS")
+                        .messages("Notification test successfully")
                         .build()
         );
     }

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/controller/NotificationController.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/controller/NotificationController.java
@@ -8,10 +8,7 @@ import org.retrade.feedback_notification.service.NotificationService;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -34,6 +31,18 @@ public class NotificationController {
                   .unwrapPaginationWrapper(notifications)
                   .messages("Notification retrieved successfully")
                   .build()
+        );
+    }
+
+    @PatchMapping("{id}/read")
+    public ResponseEntity<ResponseObject<Void>> markAsRead(@PathVariable String id) {
+        notificationService.markAsRead(id);
+        return ResponseEntity.ok(
+                new ResponseObject.Builder<Void>()
+                        .success(true)
+                        .code("SUCCESS")
+                        .messages("Notification mark successfully")
+                        .build()
         );
     }
 }

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/constant/JwtTokenType.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/constant/JwtTokenType.java
@@ -1,7 +1,5 @@
 package org.retrade.feedback_notification.model.constant;
 
 public enum JwtTokenType {
-    ACCESS_TOKEN,
-    REFRESH_TOKEN,
-    TWO_FA_TOKEN
+    ACCESS_TOKEN
 }

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/constant/JwtTokenType.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/constant/JwtTokenType.java
@@ -1,0 +1,7 @@
+package org.retrade.feedback_notification.model.constant;
+
+public enum JwtTokenType {
+    ACCESS_TOKEN,
+    REFRESH_TOKEN,
+    TWO_FA_TOKEN
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/constant/NotificationTypeCode.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/constant/NotificationTypeCode.java
@@ -1,0 +1,8 @@
+package org.retrade.feedback_notification.model.constant;
+
+public class NotificationTypeCode {
+    public static final String SYSTEM = "SYSTEM";
+    public static final String CHAT = "CHAT";
+    public static final String ORDER = "ORDER";
+    public static final String ALERT = "ALERT";
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/dto/NotificationRequest.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/dto/NotificationRequest.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class NotificationRequest {
+    private String title;
+    private String message;
     private String content;
-    private String type;
 }

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/dto/NotificationRequest.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/dto/NotificationRequest.java
@@ -1,0 +1,15 @@
+package org.retrade.feedback_notification.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationRequest {
+    private String content;
+    private String type;
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/dto/NotificationResponse.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/dto/NotificationResponse.java
@@ -1,0 +1,23 @@
+package org.retrade.feedback_notification.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationResponse {
+    private String id;
+    private String type;
+    private String title;
+    private String content;
+    private boolean read;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    private LocalDateTime createdDate;
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/entity/AccountEntity.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/entity/AccountEntity.java
@@ -2,20 +2,22 @@ package org.retrade.feedback_notification.model.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.retrade.common.model.entity.BaseSQLEntity;
+
+import java.util.Set;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @Entity(name = "accounts")
 public class AccountEntity extends BaseSQLEntity {
     @Column(name = "account_id", unique = true, nullable = false)
     private String accountId;
     @Column(name = "username", unique = true, nullable = false)
     private String username;
+    @Column(name = "roles", nullable = false)
+    private Set<String> roles;
 }

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/entity/AccountEntity.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/entity/AccountEntity.java
@@ -1,0 +1,21 @@
+package org.retrade.feedback_notification.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.retrade.common.model.entity.BaseSQLEntity;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "accounts")
+public class AccountEntity extends BaseSQLEntity {
+    @Column(name = "account_id", unique = true, nullable = false)
+    private String accountId;
+    @Column(name = "username", unique = true, nullable = false)
+    private String username;
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/entity/NotificationEntity.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/entity/NotificationEntity.java
@@ -1,16 +1,14 @@
 package org.retrade.feedback_notification.model.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.retrade.common.model.entity.BaseSQLEntity;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 @Entity(name = "notifications")
 public class NotificationEntity extends BaseSQLEntity {
     @ManyToOne(fetch = FetchType.LAZY, targetEntity = AccountEntity.class)

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/entity/NotificationEntity.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/entity/NotificationEntity.java
@@ -1,0 +1,29 @@
+package org.retrade.feedback_notification.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.retrade.common.model.entity.BaseSQLEntity;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "notifications")
+public class NotificationEntity extends BaseSQLEntity {
+    @ManyToOne(fetch = FetchType.LAZY, targetEntity = AccountEntity.class)
+    @JoinColumn(name = "account_id")
+    private AccountEntity account;
+    @Column(name = "title")
+    private String title;
+    @Column(name = "message", length = 256)
+    private String message;
+    @Column(name = "type")
+    private String type;
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+    @Column(name = "read", columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean read;
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/other/UserClaims.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/model/other/UserClaims.java
@@ -1,0 +1,20 @@
+package org.retrade.feedback_notification.model.other;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.retrade.feedback_notification.model.constant.JwtTokenType;
+
+import java.util.List;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserClaims {
+    private String username;
+    private List<String> roles;
+    private JwtTokenType tokenType;
+    private String sessionId;
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/repository/AccountRepository.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/repository/AccountRepository.java
@@ -1,0 +1,14 @@
+package org.retrade.feedback_notification.repository;
+
+import org.retrade.common.repository.BaseJpaRepository;
+import org.retrade.feedback_notification.model.entity.AccountEntity;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AccountRepository extends BaseJpaRepository<AccountEntity, String> {
+    Optional<AccountEntity> findByAccountId(String accountId);
+
+    Optional<AccountEntity> findByUsername(String username);
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/repository/NotificationRepository.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/repository/NotificationRepository.java
@@ -1,0 +1,9 @@
+package org.retrade.feedback_notification.repository;
+
+import org.retrade.common.repository.BaseJpaRepository;
+import org.retrade.feedback_notification.model.entity.NotificationEntity;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends BaseJpaRepository<NotificationEntity, String> {
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/repository/NotificationRepository.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/repository/NotificationRepository.java
@@ -1,9 +1,14 @@
 package org.retrade.feedback_notification.repository;
 
 import org.retrade.common.repository.BaseJpaRepository;
+import org.retrade.feedback_notification.model.entity.AccountEntity;
 import org.retrade.feedback_notification.model.entity.NotificationEntity;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface NotificationRepository extends BaseJpaRepository<NotificationEntity, String> {
+
+    Optional<NotificationEntity> findByIdAndAccount(String id, AccountEntity account);
 }

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/security/CustomAuthenticationEntryPoint.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,22 @@
+package org.retrade.feedback_notification.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final HandlerExceptionResolver handlerExceptionResolver;
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        handlerExceptionResolver.resolveException(request, response, null, authException);
+    }
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/security/JwtAuthenticationFilter.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/security/JwtAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package org.retrade.feedback_notification.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.retrade.feedback_notification.client.TokenServiceClient;
+import org.retrade.feedback_notification.util.TokenUtils;
+import org.retrade.proto.authentication.TokenType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final TokenServiceClient tokenServiceClient;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,@NonNull HttpServletResponse response,@NonNull FilterChain filterChain) throws ServletException, IOException {
+        String accessToken = TokenUtils.getTokenFromHeader(request);
+        if (accessToken != null) {
+            var userClaims = tokenServiceClient.verifyToken(accessToken, TokenType.ACCESS_TOKEN);
+            if (userClaims.getIsValid()) {
+                var claims = userClaims.getUserInfo();
+                var roles = claims.getRolesList().stream().map(SimpleGrantedAuthority::new).toList();
+                UserDetails userDetails = User.builder()
+                        .username(claims.getUsername())
+                        .password("")
+                        .authorities(roles)
+                        .disabled(!claims.getIsActive())
+                        .accountLocked(!claims.getIsVerified())
+                        .build();
+                UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/security/JwtAuthenticationFilter.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/security/JwtAuthenticationFilter.java
@@ -6,16 +6,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.retrade.feedback_notification.client.TokenServiceClient;
+import org.retrade.feedback_notification.model.constant.JwtTokenType;
+import org.retrade.feedback_notification.service.JwtService;
+import org.retrade.feedback_notification.service.impl.UserDetailServiceImpl;
 import org.retrade.feedback_notification.util.TokenUtils;
-import org.retrade.proto.authentication.TokenType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.retrade.feedback_notification.util.UserClaimUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -23,29 +18,16 @@ import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-    private final TokenServiceClient tokenServiceClient;
+    private final UserDetailServiceImpl userDetailService;
+    private final JwtService jwtService;
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request,@NonNull HttpServletResponse response,@NonNull FilterChain filterChain) throws ServletException, IOException {
         String accessToken = TokenUtils.getTokenFromHeader(request);
         if (accessToken != null) {
-            var userClaims = tokenServiceClient.verifyToken(accessToken, TokenType.ACCESS_TOKEN);
-            if (userClaims.getIsValid()) {
-                var claims = userClaims.getUserInfo();
-                var roles = claims.getRolesList().stream().map(SimpleGrantedAuthority::new).toList();
-                UserDetails userDetails = User.builder()
-                        .username(claims.getUsername())
-                        .password("")
-                        .authorities(roles)
-                        .disabled(!claims.getIsActive())
-                        .accountLocked(!claims.getIsVerified())
-                        .build();
-                UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-                authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                SecurityContextHolder.getContext().setAuthentication(authenticationToken);
-            }
+            var userClaims = jwtService.getUserClaimsFromJwt(accessToken, JwtTokenType.ACCESS_TOKEN);
+            UserClaimUtils.handleUserClaim(request, userClaims, userDetailService);
         }
         filterChain.doFilter(request, response);
     }

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/security/JwtCookieAuthenticationFilter.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/security/JwtCookieAuthenticationFilter.java
@@ -1,0 +1,38 @@
+package org.retrade.feedback_notification.security;
+
+import jakarta.annotation.Nonnull;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.retrade.feedback_notification.model.constant.JwtTokenType;
+import org.retrade.feedback_notification.service.impl.JwtServiceImpl;
+import org.retrade.feedback_notification.service.impl.UserDetailServiceImpl;
+import org.retrade.feedback_notification.util.CookieUtils;
+import org.retrade.feedback_notification.util.UserClaimUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.EnumMap;
+
+@Component
+@RequiredArgsConstructor
+public class JwtCookieAuthenticationFilter extends OncePerRequestFilter {
+    private final UserDetailServiceImpl userDetailService;
+    private final JwtServiceImpl jwtService;
+    @Override
+    protected void doFilterInternal(@Nonnull HttpServletRequest request, @Nonnull HttpServletResponse response,@Nonnull FilterChain filterChain) throws ServletException, IOException {
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        EnumMap<JwtTokenType, Cookie> cookieMap = CookieUtils.getCookieMap(request);
+        var userClaims = jwtService.getUserClaimsFromJwt(cookieMap);
+        UserClaimUtils.handleUserClaim(request, userClaims, userDetailService);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/JwtService.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/JwtService.java
@@ -1,0 +1,35 @@
+package org.retrade.feedback_notification.service;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.retrade.feedback_notification.model.constant.JwtTokenType;
+import org.retrade.feedback_notification.model.other.UserClaims;
+import org.springframework.security.core.Authentication;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Optional;
+
+public interface JwtService {
+    String generateToken(Authentication authentication, JwtTokenType tokenType);
+
+    Claims generateClaims(UserClaims claimInfo);
+
+    String generateToken(String username, List<String> role, JwtTokenType tokenType);
+
+    String generateToken(UserClaims userClaims);
+
+    Optional<UserClaims> getUserClaimsFromJwt(String token, JwtTokenType tokenType);
+
+    Optional<UserClaims> getUserClaimsFromJwt(EnumMap<JwtTokenType, Cookie> cookieEnumMap);
+
+    Cookie tokenCookieWarp(String token, JwtTokenType tokenType);
+
+    void removeAuthToken (HttpServletRequest request, HttpServletResponse response);
+
+    void removeAuthToken(Cookie cookie, HttpServletResponse response);
+
+    boolean isTokenValid(String token, JwtTokenType tokenType);
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/NotificationService.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/NotificationService.java
@@ -1,0 +1,11 @@
+package org.retrade.feedback_notification.service;
+
+import org.retrade.common.model.dto.request.QueryWrapper;
+import org.retrade.common.model.dto.response.PaginationWrapper;
+import org.retrade.feedback_notification.model.dto.NotificationResponse;
+
+import java.util.List;
+
+public interface NotificationService {
+    PaginationWrapper<List<NotificationResponse>> getNotifications(QueryWrapper queryWrapper);
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/NotificationService.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/NotificationService.java
@@ -2,11 +2,17 @@ package org.retrade.feedback_notification.service;
 
 import org.retrade.common.model.dto.request.QueryWrapper;
 import org.retrade.common.model.dto.response.PaginationWrapper;
+import org.retrade.feedback_notification.model.dto.NotificationRequest;
 import org.retrade.feedback_notification.model.dto.NotificationResponse;
 
 import java.util.List;
 
 public interface NotificationService {
     PaginationWrapper<List<NotificationResponse>> getNotifications(QueryWrapper queryWrapper);
+
+    NotificationResponse makeNotification(NotificationRequest notificationRequest);
+
+    void testGlobalNotification();
+
     void markAsRead(String id);
 }

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/NotificationService.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/NotificationService.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface NotificationService {
     PaginationWrapper<List<NotificationResponse>> getNotifications(QueryWrapper queryWrapper);
+    void markAsRead(String id);
 }

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/WebSocketService.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/WebSocketService.java
@@ -1,4 +1,9 @@
 package org.retrade.feedback_notification.service;
 
+import org.retrade.feedback_notification.model.dto.NotificationResponse;
+
 public interface WebSocketService {
+    void sentToUser(String userId, NotificationResponse notificationResponse);
+
+    void sentToAll(NotificationResponse notificationResponse);
 }

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/WebSocketService.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/WebSocketService.java
@@ -1,0 +1,4 @@
+package org.retrade.feedback_notification.service;
+
+public interface WebSocketService {
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/impl/JwtServiceImpl.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/impl/JwtServiceImpl.java
@@ -1,0 +1,180 @@
+package org.retrade.feedback_notification.service.impl;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.retrade.feedback_notification.config.security.HostConfig;
+import org.retrade.feedback_notification.config.security.JwtConfig;
+import org.retrade.feedback_notification.model.constant.JwtTokenType;
+import org.retrade.feedback_notification.model.other.UserClaims;
+import org.retrade.feedback_notification.service.JwtService;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.sql.Date;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class JwtServiceImpl implements JwtService {
+
+    private final JwtConfig jwtTokenConfig;
+    private final HostConfig hostConfig;
+
+    @Override
+    public String generateToken(Authentication authentication, JwtTokenType tokenType) {
+        UserDetails user = (UserDetails) authentication.getPrincipal();
+        var roles = user.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+        return generateToken(UserClaims.builder()
+                .username(user.getUsername())
+                .roles(roles)
+                .tokenType(tokenType)
+                .build());
+    }
+
+    @Override
+    public Claims generateClaims(UserClaims claimInfo) {
+        Claims claims = Jwts.claims();
+        claims.put("user", claimInfo);
+        return claims;
+    }
+
+    @Override
+    public String generateToken(String username, List<String> roles, JwtTokenType tokenType) {
+        return generateToken(UserClaims.builder()
+                .username(username)
+                .roles(roles)
+                .tokenType(tokenType)
+                .build());
+    }
+
+    @Override
+    public String generateToken(UserClaims userClaims) {
+        Date currentDate = new Date(System.currentTimeMillis());
+        Date expiryDate = getExpiryDate(userClaims.getTokenType(), currentDate);
+
+        return Jwts.builder()
+                .setSubject(userClaims.getUsername())
+                .setIssuedAt(currentDate)
+                .setClaims(generateClaims(userClaims))
+                .setExpiration(expiryDate)
+                .signWith(getSigningKey(userClaims.getTokenType()))
+                .compact();
+    }
+
+    private SecretKey getSigningKey(JwtTokenType tokenType) {
+        String secretKey = switch (tokenType) {
+            case ACCESS_TOKEN -> jwtTokenConfig.getAccessToken().getKey();
+        };
+        return Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
+    }
+
+    @Override
+    public Optional<UserClaims> getUserClaimsFromJwt(String token, JwtTokenType tokenType) {
+        try {
+            var claims = Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey(tokenType))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            String userJson = objectMapper.writeValueAsString(claims.get("user"));
+            return Optional.of(objectMapper.readValue(userJson, UserClaims.class));
+        } catch (Exception ex) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<UserClaims> getUserClaimsFromJwt(EnumMap<JwtTokenType, Cookie> cookieEnumMap) {
+        return cookieEnumMap.entrySet().stream()
+                .map(entry -> getUserClaimsFromJwt(entry.getValue().getValue(), entry.getKey()))
+                .filter(Optional::isPresent)
+                .findFirst()
+                .orElse(Optional.empty());
+    }
+
+    @Override
+    public Cookie tokenCookieWarp(String token, JwtTokenType tokenType) {
+        long jwtEx = switch (tokenType) {
+            case ACCESS_TOKEN -> jwtTokenConfig.getAccessToken().getMaxAge();
+        };
+
+        var cookie = new Cookie(tokenType.toString(), token);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setMaxAge((int) jwtEx);
+        cookie.setAttribute("SameSite", "None");
+
+        if (!hostConfig.getBaseHost().isEmpty() && !hostConfig.getDevelopMode()) {
+            cookie.setDomain(hostConfig.getBaseHost());
+        }
+
+        return cookie;
+    }
+
+    @Override
+    public void removeAuthToken(HttpServletRequest request, HttpServletResponse response) {
+        var cookieRequest = request.getCookies();
+        if (cookieRequest == null) {
+            return;
+        }
+        var authCookies = Arrays.stream(cookieRequest)
+                .filter(cookie -> cookie.getName().equals(JwtTokenType.ACCESS_TOKEN.toString()))
+                .toList();
+
+        authCookies.forEach(cookie -> removeAuthToken(cookie, response));
+    }
+
+    @Override
+    public void removeAuthToken(Cookie cookie, HttpServletResponse response) {
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        cookie.setValue("");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "None");
+
+        if (!hostConfig.getBaseHost().isEmpty() && !hostConfig.getDevelopMode()) {
+            cookie.setDomain(hostConfig.getBaseHost());
+        }
+
+        response.addCookie(cookie);
+    }
+
+    @Override
+    public boolean isTokenValid(String token, JwtTokenType tokenType) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey(tokenType))
+                    .build()
+                    .parseClaimsJws(token);
+        } catch (Exception ex) {
+            return false;
+        }
+        return true;
+    }
+
+    private Date getExpiryDate(JwtTokenType tokenType, Date currentDate) {
+        long duration = switch (tokenType) {
+            case ACCESS_TOKEN -> jwtTokenConfig.getAccessToken().getMaxAge();
+        };
+        return new Date(currentDate.getTime() + duration);
+    }
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/impl/MessageConsumerServiceImpl.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/impl/MessageConsumerServiceImpl.java
@@ -8,7 +8,7 @@ import com.rabbitmq.client.Channel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.retrade.common.model.message.MessageObject;
-import org.retrade.feedback_notification.config.RabbitMQConfig;
+import org.retrade.feedback_notification.config.common.RabbitMQConfig;
 import org.retrade.feedback_notification.model.message.EmailNotificationMessage;
 import org.retrade.feedback_notification.model.message.UserRegistrationMessage;
 import org.retrade.feedback_notification.service.EmailService;

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/impl/NotificationServiceImpl.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/impl/NotificationServiceImpl.java
@@ -1,0 +1,60 @@
+package org.retrade.feedback_notification.service.impl;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import lombok.RequiredArgsConstructor;
+import org.retrade.common.model.dto.request.QueryFieldWrapper;
+import org.retrade.common.model.dto.request.QueryWrapper;
+import org.retrade.common.model.dto.response.PaginationWrapper;
+import org.retrade.feedback_notification.model.dto.NotificationResponse;
+import org.retrade.feedback_notification.model.entity.NotificationEntity;
+import org.retrade.feedback_notification.repository.NotificationRepository;
+import org.retrade.feedback_notification.service.NotificationService;
+import org.retrade.feedback_notification.service.WebSocketService;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+    private final NotificationRepository notificationRepository;
+    private final WebSocketService webSocketService;
+
+    @Override
+    public PaginationWrapper<List<NotificationResponse>> getNotifications(QueryWrapper queryWrapper) {
+        return notificationRepository.query(queryWrapper, (param) -> ((root, query, criteriaBuilder) -> {
+            var predicates = new ArrayList<Predicate>();
+            return getPredicate(param, root, criteriaBuilder, predicates);
+        }), (items) -> {
+            var response = items.stream().map(this::wrapToNotificationResponse).toList();
+            return new PaginationWrapper.Builder<List<NotificationResponse>>()
+                    .setPaginationInfo(items)
+                    .setData(response)
+                    .build();
+        });
+    }
+
+    private Predicate getPredicate(Map<String, QueryFieldWrapper> param, Root<NotificationEntity> root, CriteriaBuilder criteriaBuilder, List<Predicate> predicates) {
+        if (param != null && !param.isEmpty()) {
+            Predicate[] defaultPredicates = notificationRepository.createDefaultPredicate(criteriaBuilder, root, param);
+            predicates.addAll(Arrays.asList(defaultPredicates));
+        }
+        return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+    }
+
+    private NotificationResponse wrapToNotificationResponse(NotificationEntity notificationEntity) {
+        return NotificationResponse.builder()
+                .id(notificationEntity.getId())
+                .type(notificationEntity.getType())
+                .title(notificationEntity.getTitle())
+                .content(notificationEntity.getContent())
+                .read(notificationEntity.isRead())
+                .createdDate(notificationEntity.getCreatedDate().toLocalDateTime())
+                .build();
+    }
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/impl/UserDetailServiceImpl.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/impl/UserDetailServiceImpl.java
@@ -38,9 +38,15 @@ public class UserDetailServiceImpl implements UserDetailsService {
                     .build();
             return accountRepository.save(accountSave);
         });
-        return User.builder()
-                .username(account.getUsername())
-                .authorities(AuthUtils.convertRoleToAuthority(account))
-                .build();
+        var authorities = AuthUtils.convertRoleToAuthority(account);
+        return new User(
+                account.getUsername(),
+                "",
+                true,
+                true,
+                true,
+                true,
+                authorities
+        );
     }
 }

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/impl/UserDetailServiceImpl.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/impl/UserDetailServiceImpl.java
@@ -1,0 +1,46 @@
+package org.retrade.feedback_notification.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.retrade.feedback_notification.client.TokenServiceClient;
+import org.retrade.feedback_notification.model.entity.AccountEntity;
+import org.retrade.feedback_notification.repository.AccountRepository;
+import org.retrade.feedback_notification.util.AuthUtils;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailServiceImpl implements UserDetailsService {
+    private final AccountRepository accountRepository;
+    private final TokenServiceClient tokenServiceClient;
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        var account = accountRepository.findByUsername(username).orElseGet(() -> {
+            var grpcResponse = tokenServiceClient.getAccountInfoByUsername(username);
+            if (!grpcResponse.getIsValid()) {
+                throw new UsernameNotFoundException("User not found");
+            }
+            var userInfo = grpcResponse.getUserInfo();
+            if (userInfo.getChangedUsername()) {
+                var accountEntity = accountRepository.findByAccountId(userInfo.getAccountId()).orElseThrow(() -> new UsernameNotFoundException("User not found"));
+                accountEntity.setUsername(username);
+                return accountRepository.save(accountEntity);
+            }
+            var accountSave = AccountEntity.builder()
+                    .username(username)
+                    .accountId(userInfo.getAccountId())
+                    .roles(new HashSet<>(userInfo.getRolesList()))
+                    .build();
+            return accountRepository.save(accountSave);
+        });
+        return User.builder()
+                .username(account.getUsername())
+                .authorities(AuthUtils.convertRoleToAuthority(account))
+                .build();
+    }
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/impl/WebSocketServiceImpl.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/impl/WebSocketServiceImpl.java
@@ -1,6 +1,7 @@
 package org.retrade.feedback_notification.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.retrade.feedback_notification.model.dto.NotificationResponse;
 import org.retrade.feedback_notification.service.WebSocketService;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -10,9 +11,13 @@ import org.springframework.stereotype.Service;
 public class WebSocketServiceImpl implements WebSocketService {
     private final SimpMessagingTemplate messagingTemplate;
 
-    public void sendMessage(String destination, Object payload) {
-        messagingTemplate.convertAndSendToUser(destination,
-                "/queue/notifications",
-                payload);
+    @Override
+    public void sentToUser(String userId, NotificationResponse notificationResponse) {
+        messagingTemplate.convertAndSendToUser(userId, "/queue/notifications", notificationResponse);
+    }
+
+    @Override
+    public void sentToAll(NotificationResponse notificationResponse) {
+        messagingTemplate.convertAndSend("/topic/notifications", notificationResponse) ;
     }
 }

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/impl/WebSocketServiceImpl.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/service/impl/WebSocketServiceImpl.java
@@ -1,0 +1,18 @@
+package org.retrade.feedback_notification.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.retrade.feedback_notification.service.WebSocketService;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WebSocketServiceImpl implements WebSocketService {
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void sendMessage(String destination, Object payload) {
+        messagingTemplate.convertAndSendToUser(destination,
+                "/queue/notifications",
+                payload);
+    }
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/util/AuthUtils.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/util/AuthUtils.java
@@ -1,0 +1,56 @@
+package org.retrade.feedback_notification.util;
+
+import lombok.RequiredArgsConstructor;
+import org.retrade.feedback_notification.model.entity.AccountEntity;
+import org.retrade.feedback_notification.repository.AccountRepository;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUtils {
+    private final AccountRepository accountRepository;
+    public AccountEntity getUserAccountFromAuthentication() {
+        try {
+            var auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth == null) { throw new AuthenticationException("Authentication required") {}; }
+            String username = auth.getName();
+            return accountRepository.findByUsername(username).orElseThrow();
+        } catch (Exception ex) {
+            throw new AuthenticationException("This user isn't authentication, please login again") {};
+        }
+    }
+    public Optional<AccountEntity> getCurrentUserAccount() {
+        try {
+            var auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth == null) return Optional.empty();
+            String username = auth.getName();
+            return accountRepository.findByUsername(username);
+        } catch (Exception ex) {
+            return Optional.empty();
+        }
+    }
+
+    public Set<String> getRolesFromAuthUser() {
+        var account = getUserAccountFromAuthentication();
+        return new HashSet<>(convertAccountToRole(account));
+    }
+
+    public static Collection<GrantedAuthority> convertRoleToAuthority (AccountEntity account) {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        account.getRoles().forEach(role -> {
+            authorities.add(new SimpleGrantedAuthority(role));
+        });
+        return authorities;
+    }
+
+    public static List<String> convertAccountToRole (AccountEntity account) {
+        return convertRoleToAuthority(account).stream().map(GrantedAuthority::getAuthority).collect(Collectors.toList());
+    }
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/util/CookieUtils.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/util/CookieUtils.java
@@ -1,0 +1,40 @@
+package org.retrade.feedback_notification.util;
+
+import jakarta.annotation.Nonnull;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.retrade.feedback_notification.model.constant.JwtTokenType;
+
+import java.util.Arrays;
+import java.util.EnumMap;
+
+
+public class CookieUtils {
+    public static Cookie[] getCookies(@Nonnull HttpServletRequest request) {
+        var cookies = request.getCookies();
+        if (cookies == null) {
+            return new Cookie[0];
+        }
+        return cookies;
+    }
+    public static EnumMap<JwtTokenType, Cookie> getCookieMap(@Nonnull HttpServletRequest request) {
+        EnumMap<JwtTokenType, Cookie> cookieMap = new EnumMap<>(JwtTokenType.class);
+        Arrays.stream(CookieUtils.getCookies(request))
+                .filter(CookieUtils::validateValidCookie)
+                .forEach(cookie -> cookieMap.put(JwtTokenType.valueOf(cookie.getName().toUpperCase()), cookie));
+        return cookieMap;
+    }
+    public static boolean validateValidCookie(@Nonnull Cookie cookie) {
+        String cookieName = cookie.getName();
+        String cookieValue = cookie.getValue();
+        if (cookieName == null || cookieValue == null || cookieValue.isEmpty()) {
+            return false;
+        }
+        try {
+            JwtTokenType.valueOf(cookieName.toUpperCase());
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/util/TokenUtils.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/util/TokenUtils.java
@@ -1,0 +1,13 @@
+package org.retrade.feedback_notification.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class TokenUtils {
+    public static String getTokenFromHeader(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/services/feedback-notification/src/main/java/org/retrade/feedback_notification/util/UserClaimUtils.java
+++ b/services/feedback-notification/src/main/java/org/retrade/feedback_notification/util/UserClaimUtils.java
@@ -1,0 +1,23 @@
+package org.retrade.feedback_notification.util;
+
+import jakarta.annotation.Nonnull;
+import jakarta.servlet.http.HttpServletRequest;
+import org.retrade.feedback_notification.model.other.UserClaims;
+import org.retrade.feedback_notification.service.impl.UserDetailServiceImpl;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+
+import java.util.Optional;
+
+public class UserClaimUtils {
+    public static void handleUserClaim(@Nonnull HttpServletRequest request, Optional<UserClaims> userClaims, UserDetailServiceImpl userDetailService) {
+        if (userClaims.isPresent()) {
+            var claims = userClaims.get();
+            var userDetails = userDetailService.loadUserByUsername(claims.getUsername());
+            UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        }
+    }
+}

--- a/services/feedback-notification/src/main/resources/application.yaml
+++ b/services/feedback-notification/src/main/resources/application.yaml
@@ -59,11 +59,17 @@ logging:
     org.springframework.amqp.rabbit.listener: DEBUG
 
 security:
+  token:
+    jwt:
+      access-token:
+        key: ${JWT_ACCESS_KEY}
+        max-age: ${JWT_ACCESS_EX:3000}
   host:
     origin-allows: ${ORIGIN_ALLOWS:}
     base-host: ${BASE_HOST:}
     front-end: ${FRONTEND_URL}
     swagger-context-path: ${SWAGGER_CONTEXT_PATH:/api/v1}
+    develop-mode: ${DEVELOP_MODE:true}
 
 grpc:
   client:

--- a/services/feedback-notification/src/main/resources/application.yaml
+++ b/services/feedback-notification/src/main/resources/application.yaml
@@ -1,6 +1,20 @@
 spring:
   application:
       name: Feedback Notification Service
+  datasource:
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:12345}
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME}
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        default_schema: notification
   grpc:
     server:
       enabled: true
@@ -50,6 +64,12 @@ security:
     base-host: ${BASE_HOST:}
     front-end: ${FRONTEND_URL}
     swagger-context-path: ${SWAGGER_CONTEXT_PATH:/api/v1}
+
+grpc:
+  client:
+    main-service:
+      host: ${MAIN_SERVICE_GRPC_HOST:localhost}
+      port: ${MAIN_SERVICE_GRPC_PORT:9080}
 
 
 springdoc:

--- a/services/main/src/main/java/org/retrade/main/config/common/CronjobConfig.java
+++ b/services/main/src/main/java/org/retrade/main/config/common/CronjobConfig.java
@@ -1,0 +1,28 @@
+package org.retrade.main.config.common;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+@Configuration
+@EnableScheduling
+public class CronjobConfig implements SchedulingConfigurer {
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5);
+        scheduler.setThreadNamePrefix("rating-sync-");
+        scheduler.setAwaitTerminationSeconds(60);
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        return scheduler;
+    }
+
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        taskRegistrar.setScheduler(taskRegistrar.getScheduler());
+    }
+}

--- a/services/main/src/main/java/org/retrade/main/controller/DashboardController.java
+++ b/services/main/src/main/java/org/retrade/main/controller/DashboardController.java
@@ -79,4 +79,15 @@ public class DashboardController {
                 .build());
     }
 
+    @GetMapping("seller/product/metric")
+    public ResponseEntity<ResponseObject<SellerProductBaseMetricResponse>> getSellerProductMetric() {
+        var result = dashboardService.getSellerProductMetric();
+        return ResponseEntity.ok(new ResponseObject.Builder<SellerProductBaseMetricResponse>()
+                .success(true)
+                .code("SELLER_DASHBOARD_RETRIEVED")
+                .content(result)
+                .messages("Seller Dashboard retrieved successfully")
+                .build());
+    }
+
 }

--- a/services/main/src/main/java/org/retrade/main/controller/DashboardController.java
+++ b/services/main/src/main/java/org/retrade/main/controller/DashboardController.java
@@ -90,4 +90,15 @@ public class DashboardController {
                 .build());
     }
 
+    @GetMapping("seller/order/metric")
+    public ResponseEntity<ResponseObject<SellerOrderBaseMetricResponse>> getSellerOrderMetric() {
+        var result = dashboardService.getSellerOrderMetric();
+        return ResponseEntity.ok(new ResponseObject.Builder<SellerOrderBaseMetricResponse>()
+                .success(true)
+                .code("SELLER_DASHBOARD_RETRIEVED")
+                .content(result)
+                .messages("Seller Dashboard retrieved successfully")
+                .build());
+    }
+
 }

--- a/services/main/src/main/java/org/retrade/main/controller/ProductController.java
+++ b/services/main/src/main/java/org/retrade/main/controller/ProductController.java
@@ -208,6 +208,22 @@ public class ProductController {
                 .build());
     }
 
+    @GetMapping("seller/filter")
+    public ResponseEntity<ResponseObject<FieldAdvanceSearch>> getSellerProductFilter(
+            @RequestParam(required = false, name = "q") String search
+    ) {
+        var queryWrapper = QueryWrapper.builder()
+                .search(search)
+                .build();
+        var result = productService.sellerFiledAdvanceSearch(queryWrapper);
+        return ResponseEntity.ok(new ResponseObject.Builder<FieldAdvanceSearch>()
+                .success(true)
+                .code("SUCCESS")
+                .content(result)
+                .messages("Filter product found successfully")
+                .build());
+    }
+
     @GetMapping("category/{categoryName}")
     public ResponseEntity<ResponseObject<List<ProductResponse>>> getProductsByCategory(
             @PathVariable String categoryName,

--- a/services/main/src/main/java/org/retrade/main/cron/PaymentStatusCronjob.java
+++ b/services/main/src/main/java/org/retrade/main/cron/PaymentStatusCronjob.java
@@ -1,0 +1,4 @@
+package org.retrade.main.cron;
+
+public class PaymentStatusCronjob {
+}

--- a/services/main/src/main/java/org/retrade/main/cron/ProductReviewCronjob.java
+++ b/services/main/src/main/java/org/retrade/main/cron/ProductReviewCronjob.java
@@ -1,0 +1,31 @@
+package org.retrade.main.cron;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.retrade.main.repository.jpa.ProductRepository;
+import org.retrade.main.repository.jpa.SellerRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class ProductReviewCronjob {
+    private final ProductRepository productRepository;
+    private final SellerRepository sellerRepository;
+    private LocalDateTime lastSyncTime = LocalDateTime.now().minusDays(1);
+
+    @Scheduled(cron = "0 0 2 * * *")
+    @Transactional
+    public void syncUpdatedRatings() {
+        try {
+            productRepository.updateProductAverageRatings(lastSyncTime);
+            sellerRepository.updateSellerAverageRatings(lastSyncTime);
+            lastSyncTime = LocalDateTime.now();
+            System.out.println("Rating synchronization completed at " + lastSyncTime);
+        } catch (Exception e) {
+            System.out.println("Error during rating synchronization: " + e.getMessage());
+        }
+    }
+}

--- a/services/main/src/main/java/org/retrade/main/grpc/TokenGrpcServiceImpl.java
+++ b/services/main/src/main/java/org/retrade/main/grpc/TokenGrpcServiceImpl.java
@@ -208,6 +208,7 @@ public class TokenGrpcServiceImpl extends GrpcTokenServiceGrpc.GrpcTokenServiceI
                     .setIsValid(false)
                     .addErrorMessages("Account does not exist")
                     .build());
+            responseObserver.onCompleted();
             return;
         }
         var account = accountOptional.get();
@@ -223,6 +224,7 @@ public class TokenGrpcServiceImpl extends GrpcTokenServiceGrpc.GrpcTokenServiceI
                         .setIsVerified(!account.isLocked())
                         .setChangedUsername(account.isChangedUsername())
                         .build()).build());
+        responseObserver.onCompleted();
     }
 
     private void wrapSellerProfileResponse(StreamObserver<GetSellerProfileResponse> responseObserver, SellerEntity seller, AccountEntity account, List<String> roles) {

--- a/services/main/src/main/java/org/retrade/main/model/dto/response/SellerOrderBaseMetricResponse.java
+++ b/services/main/src/main/java/org/retrade/main/model/dto/response/SellerOrderBaseMetricResponse.java
@@ -1,0 +1,20 @@
+package org.retrade.main.model.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SellerOrderBaseMetricResponse {
+    private Long totalOrder;
+    private Long orderCompleted;
+    private Long orderCancelled;
+    private BigDecimal totalPaymentReceived;
+}

--- a/services/main/src/main/java/org/retrade/main/model/dto/response/SellerProductBaseMetricResponse.java
+++ b/services/main/src/main/java/org/retrade/main/model/dto/response/SellerProductBaseMetricResponse.java
@@ -1,0 +1,18 @@
+package org.retrade.main.model.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SellerProductBaseMetricResponse {
+    private Long totalPrice;
+    private Long productApprove;
+    private Long productActivate;
+    private Long productQuantity;
+}

--- a/services/main/src/main/java/org/retrade/main/repository/jpa/ProductRepository.java
+++ b/services/main/src/main/java/org/retrade/main/repository/jpa/ProductRepository.java
@@ -1,6 +1,7 @@
 package org.retrade.main.repository.jpa;
 
 import org.retrade.common.repository.BaseJpaRepository;
+import org.retrade.main.model.constant.ProductStatusEnum;
 import org.retrade.main.model.entity.OrderEntity;
 import org.retrade.main.model.entity.ProductEntity;
 import org.retrade.main.model.entity.SellerEntity;
@@ -28,6 +29,14 @@ public interface ProductRepository extends BaseJpaRepository<ProductEntity, Stri
 
     @Query("SELECT oi.product FROM order_items oi WHERE oi.order = :order")
     List<ProductEntity> findProductsByOrder(@Param("order") OrderEntity order);
+
+    @Query("""
+        SELECT COALESCE(SUM(p.quantity * p.currentPrice), 0)
+        FROM products p
+        WHERE p.seller = :seller
+    """)
+    Long calculateTotalProductPriceBySeller(@Param("seller") SellerEntity seller);
+
 
     long countBySellerAndQuantityGreaterThan(SellerEntity seller, int quantity);
     long countBySellerAndVerifiedTrue(SellerEntity seller);
@@ -115,6 +124,9 @@ public interface ProductRepository extends BaseJpaRepository<ProductEntity, Stri
     long countDistinctSoldVerifiedProducts(@Param("statusCode") String statusCode);
 
     long countBySeller(@NonNull SellerEntity seller);
+
+    long countBySellerAndStatus(@NonNull SellerEntity seller, @NonNull ProductStatusEnum status);
+
 }
 
 

--- a/services/main/src/main/java/org/retrade/main/repository/jpa/SellerRepository.java
+++ b/services/main/src/main/java/org/retrade/main/repository/jpa/SellerRepository.java
@@ -3,13 +3,36 @@ package org.retrade.main.repository.jpa;
 import org.retrade.common.repository.BaseJpaRepository;
 import org.retrade.main.model.entity.AccountEntity;
 import org.retrade.main.model.entity.SellerEntity;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
 public interface SellerRepository extends BaseJpaRepository<SellerEntity, String> {
     Optional<SellerEntity> findByAccount(AccountEntity account);
     boolean existsByIdentityNumberIgnoreCase(@NonNull String identityNumber);
+    @Modifying
+    @Query("""
+        UPDATE sellers s
+        SET s.avgVote = (
+            SELECT COALESCE(AVG(p.avgVote), 0)
+            FROM products p
+            WHERE p.seller = s
+        )
+        WHERE s.id IN (
+            SELECT DISTINCT p.seller.id
+            FROM products p
+            WHERE p.id IN (
+                SELECT DISTINCT r.product.id
+                FROM product_reviews r
+                WHERE r.updatedDate > :lastSync
+            )
+        )
+    """)
+    void updateSellerAverageRatings(@Param("lastSync") LocalDateTime lastSync);
 }

--- a/services/main/src/main/java/org/retrade/main/service/DashboardService.java
+++ b/services/main/src/main/java/org/retrade/main/service/DashboardService.java
@@ -17,4 +17,6 @@ public interface DashboardService {
     List<TopSellingProductResponse> getBestSellerProducts();
 
     SellerProductBaseMetricResponse getSellerProductMetric();
+
+    SellerOrderBaseMetricResponse getSellerOrderMetric();
 }

--- a/services/main/src/main/java/org/retrade/main/service/DashboardService.java
+++ b/services/main/src/main/java/org/retrade/main/service/DashboardService.java
@@ -15,4 +15,6 @@ public interface DashboardService {
     List<RecentOrderResponse> getRecentOrders(int limit);
 
     List<TopSellingProductResponse> getBestSellerProducts();
+
+    SellerProductBaseMetricResponse getSellerProductMetric();
 }

--- a/services/main/src/main/java/org/retrade/main/service/ProductService.java
+++ b/services/main/src/main/java/org/retrade/main/service/ProductService.java
@@ -41,6 +41,8 @@ public interface ProductService {
 
     FieldAdvanceSearch filedAdvanceSearch(QueryWrapper queryWrapper);
 
+    FieldAdvanceSearch sellerFiledAdvanceSearch(QueryWrapper queryWrapper);
+
     PaginationWrapper<List<ProductResponse>> searchProductBestSelling(QueryWrapper queryWrapper);
 
     ProductHomeStatsResponse getStatsHome();

--- a/services/main/src/main/java/org/retrade/main/service/impl/DashboardServiceImpl.java
+++ b/services/main/src/main/java/org/retrade/main/service/impl/DashboardServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.retrade.common.model.exception.ValidationException;
 import org.retrade.main.model.constant.DashboardMetricCodes;
 import org.retrade.main.model.constant.OrderStatusCodes;
+import org.retrade.main.model.constant.ProductStatusEnum;
 import org.retrade.main.model.dto.response.*;
 import org.retrade.main.model.projection.RevenueMonthProjection;
 import org.retrade.main.repository.jpa.OrderComboRepository;
@@ -163,6 +164,25 @@ public class DashboardServiceImpl implements DashboardService {
                 .quantitySold(item.getQuantitySold())
                 .revenue(item.getRevenue())
                 .build()).toList();
+    }
+
+    @Override
+    public SellerProductBaseMetricResponse getSellerProductMetric() {
+        var account = authUtils.getUserAccountFromAuthentication();
+        if (account.getSeller() == null) {
+            throw new ValidationException("Seller is not found");
+        }
+        var seller = account.getSeller();
+        var totalPrice = productRepository.calculateTotalProductPriceBySeller(seller);
+        var productApprove = productRepository.countBySellerAndVerifiedTrue(seller);
+        var productActive = productRepository.countBySellerAndStatus(seller, ProductStatusEnum.ACTIVE);
+        var countProduct = productRepository.countBySeller(seller);
+        return SellerProductBaseMetricResponse.builder()
+                .productActivate(productActive)
+                .productApprove(productApprove)
+                .totalPrice(totalPrice)
+                .productQuantity(countProduct)
+                .build();
     }
 
 }

--- a/services/main/src/main/java/org/retrade/main/service/impl/DashboardServiceImpl.java
+++ b/services/main/src/main/java/org/retrade/main/service/impl/DashboardServiceImpl.java
@@ -185,4 +185,24 @@ public class DashboardServiceImpl implements DashboardService {
                 .build();
     }
 
+    @Override
+    public SellerOrderBaseMetricResponse getSellerOrderMetric() {
+        var account = authUtils.getUserAccountFromAuthentication();
+        if (account.getSeller() == null) {
+            throw new ValidationException("Seller is not found");
+        }
+        var seller = account.getSeller();
+        var orderStatus = orderStatusRepository.findByCode(OrderStatusCodes.COMPLETED).orElseThrow(() -> new ValidationException("Order status not found"));
+        var totalOrder = orderComboRepository.countBySeller(seller);
+        var orderCompleted = orderComboRepository.countBySellerAndOrderStatus_Code(seller, OrderStatusCodes.COMPLETED);
+        var orderCancel = orderComboRepository.countBySellerAndOrderStatus_Code(seller, OrderStatusCodes.CANCELLED);
+        var totalReceive = orderComboRepository.getTotalGrandPriceBySellerAndStatus(seller, orderStatus);
+        return SellerOrderBaseMetricResponse.builder()
+                .orderCompleted(orderCompleted)
+                .orderCancelled(orderCancel)
+                .totalPaymentReceived(totalReceive)
+                .totalOrder(totalOrder)
+                .build();
+    }
+
 }

--- a/services/main/src/main/resources/application.yaml
+++ b/services/main/src/main/resources/application.yaml
@@ -75,6 +75,7 @@ server:
   port: ${PORT:8080}
   servlet:
     context-path: ${CONTEXT_PATH:/api/v1}
+
 security:
   token:
       jwt:


### PR DESCRIPTION
- Added `getSellerProductMetric` endpoint in `DashboardController`, with logic implemented in `DashboardServiceImpl`.
- Introduced `getSellerProductFilter` endpoint in `ProductController`, with logic in `ProductServiceImpl`.
- Created `SellerProductBaseMetricResponse` DTO to encapsulate metrics like total price, approved products, active products, and total product count.
- Updated `ProductRepository` to support seller-specific queries for metrics and filtering.
- Refactored query-building logic for better seller and keyword-based elasticsearch integration.