### PR TITLE
fix: correct order ownership validation in cancellation logic

### DIFF
--- a/services/main/src/main/java/org/retrade/main/service/impl/OrderServiceImpl.java
+++ b/services/main/src/main/java/org/retrade/main/service/impl/OrderServiceImpl.java
@@ -244,7 +244,7 @@ public class OrderServiceImpl implements OrderService {
         if (!validStatus.contains(orderComboEntity.getOrderStatus().getCode())) {
             throw new ValidationException("Order combo status not valid for cancellation: " + orderComboEntity.getOrderStatus().getCode());
         }
-        if (orderComboEntity.getOrderDestination().getOrder().getCustomer().getId().equals(customerEntity.getId())) {
+        if (!orderComboEntity.getOrderDestination().getOrder().getCustomer().getId().equals(customerEntity.getId())) {
             throw new ValidationException("You are not the owner");
         }
         OrderStatusEntity cancelledStatus = orderStatusRepository.findByCode(OrderStatusCodes.CANCELLED)


### PR DESCRIPTION
- Fixed incorrect ID comparison in `OrderServiceImpl` for order combo ownership validation.
- Updated validation to ensure only the correct owner can cancel an order.