### PR TITLE
feat: introduce platform fee tier configuration management

### DIFF
--- a/services/main/src/main/java/org/retrade/main/controller/PlatformSettingController.java
+++ b/services/main/src/main/java/org/retrade/main/controller/PlatformSettingController.java
@@ -1,0 +1,39 @@
+package org.retrade.main.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.retrade.common.model.dto.request.QueryWrapper;
+import org.retrade.common.model.dto.response.ResponseObject;
+import org.retrade.main.model.dto.response.PlatformFeeTierResponse;
+import org.retrade.main.service.PlatformSettingService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("platform-settings")
+public class PlatformSettingController {
+    private final PlatformSettingService platformSettingService;
+
+    @GetMapping("fee")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    public ResponseEntity<ResponseObject<List<PlatformFeeTierResponse>>> getPlatformFeeTierConfig(@PageableDefault Pageable pageable, @RequestParam(required = false) String q) {
+        var result = platformSettingService.getAllPlatformFeeTierConfig(QueryWrapper.builder()
+                        .wrapSort(pageable)
+                        .search(q)
+                .build());
+        return ResponseEntity.ok(new ResponseObject.Builder<List<PlatformFeeTierResponse>>()
+                .success(true)
+                .code("SUCCESS")
+                .messages("Get platform fee tier config successfully.")
+                .unwrapPaginationWrapper(result)
+                .build());
+    }
+}

--- a/services/main/src/main/java/org/retrade/main/model/dto/request/CustomerAccountRegisterRequest.java
+++ b/services/main/src/main/java/org/retrade/main/model/dto/request/CustomerAccountRegisterRequest.java
@@ -47,8 +47,4 @@ public class CustomerAccountRegisterRequest {
     @NotEmpty(message = "Address must not be empty")
     @NotNull(message = "Address is required")
     private String address;
-
-    @NotEmpty(message = "Avatar URL must not be empty")
-    @NotNull(message = "Avatar URL is required")
-    private String avatarUrl;
 }

--- a/services/main/src/main/java/org/retrade/main/model/dto/response/PlatformFeeTierResponse.java
+++ b/services/main/src/main/java/org/retrade/main/model/dto/response/PlatformFeeTierResponse.java
@@ -1,0 +1,20 @@
+package org.retrade.main.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlatformFeeTierResponse {
+    private String id;
+    private BigDecimal minPrice;
+    private BigDecimal maxPrice;
+    private BigDecimal feeRate;
+    private String description;
+}

--- a/services/main/src/main/java/org/retrade/main/service/PlatformSettingService.java
+++ b/services/main/src/main/java/org/retrade/main/service/PlatformSettingService.java
@@ -1,6 +1,11 @@
 package org.retrade.main.service;
 
+import org.retrade.common.model.dto.request.QueryWrapper;
+import org.retrade.common.model.dto.response.PaginationWrapper;
+import org.retrade.main.model.dto.response.PlatformFeeTierResponse;
+
 import java.math.BigDecimal;
+import java.util.List;
 
 public interface PlatformSettingService {
     String getStringValue(String key);
@@ -10,4 +15,6 @@ public interface PlatformSettingService {
     boolean getBooleanValue(String key);
 
     BigDecimal findFeeRate(BigDecimal grandPrice);
+
+    PaginationWrapper<List<PlatformFeeTierResponse>> getAllPlatformFeeTierConfig(QueryWrapper queryWrapper);
 }

--- a/services/main/src/main/java/org/retrade/main/service/impl/RegisterServiceImpl.java
+++ b/services/main/src/main/java/org/retrade/main/service/impl/RegisterServiceImpl.java
@@ -63,7 +63,7 @@ public class RegisterServiceImpl implements RegisterService {
                 .lastName(request.getLastName())
                 .address(request.getAddress())
                 .phone(request.getPhone())
-                .avatarUrl(request.getAvatarUrl())
+                .avatarUrl("")
                 .gender(request.getGender())
                 .account(customerAccount)
                 .build();


### PR DESCRIPTION
- Added `PlatformFeeTierResponse` DTO for fee tier data representation.
- Implemented `getAllPlatformFeeTierConfig` in `PlatformSettingService` for querying fee tier configurations.
- Created `PlatformSettingController` with endpoint to retrieve fee tier configurations.
- Streamlined related query and response wrapping logic in `PlatformSettingServiceImpl`.
- Refactored avatar URL handling in `RegisterServiceImpl` and request validation.