### PR TITLE
feat: add endpoints for platform fee tier insertion and updates

### DIFF
--- a/services/main/src/main/java/org/retrade/main/controller/PlatformSettingController.java
+++ b/services/main/src/main/java/org/retrade/main/controller/PlatformSettingController.java
@@ -3,16 +3,14 @@ package org.retrade.main.controller;
 import lombok.RequiredArgsConstructor;
 import org.retrade.common.model.dto.request.QueryWrapper;
 import org.retrade.common.model.dto.response.ResponseObject;
+import org.retrade.main.model.dto.request.PlatformFeeTierInsertRequest;
 import org.retrade.main.model.dto.response.PlatformFeeTierResponse;
 import org.retrade.main.service.PlatformSettingService;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -34,6 +32,30 @@ public class PlatformSettingController {
                 .code("SUCCESS")
                 .messages("Get platform fee tier config successfully.")
                 .unwrapPaginationWrapper(result)
+                .build());
+    }
+
+    @PostMapping("fee")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    public ResponseEntity<ResponseObject<PlatformFeeTierResponse>> insertPlatformFeeTierConfig(@RequestBody PlatformFeeTierInsertRequest request) {
+        var result = platformSettingService.upsertTier(request);
+        return ResponseEntity.ok(new ResponseObject.Builder<PlatformFeeTierResponse>()
+                .success(true)
+                .code("SUCCESS")
+                .messages("Insert platform fee tier config successfully.")
+                .content(result)
+                .build());
+    }
+
+    @PutMapping("fee/{id}")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    public ResponseEntity<ResponseObject<PlatformFeeTierResponse>> updatePlatformFeeTierConfig(@RequestBody PlatformFeeTierInsertRequest request, @PathVariable String id) {
+        var result = platformSettingService.updateTier(id, request);
+        return ResponseEntity.ok(new ResponseObject.Builder<PlatformFeeTierResponse>()
+                .success(true)
+                .code("SUCCESS")
+                .messages("Update platform fee tier config successfully.")
+                .content(result)
                 .build());
     }
 }

--- a/services/main/src/main/java/org/retrade/main/model/dto/request/PlatformFeeTierInsertRequest.java
+++ b/services/main/src/main/java/org/retrade/main/model/dto/request/PlatformFeeTierInsertRequest.java
@@ -1,0 +1,31 @@
+package org.retrade.main.model.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlatformFeeTierInsertRequest {
+    @NotNull(message = "Min price is required")
+    @DecimalMin(value = "0.0", inclusive = true, message = "Min price must be >= 0")
+    private BigDecimal minPrice;
+
+    @DecimalMin(value = "0.0", inclusive = false, message = "Max price must be > 0")
+    private BigDecimal maxPrice;
+
+    @NotNull(message = "Fee rate is required")
+    @DecimalMin(value = "0.0", inclusive = true, message = "Fee rate must be >= 0")
+    @DecimalMax(value = "1.0", inclusive = true, message = "Fee rate must be <= 1")
+    private BigDecimal feeRate;
+
+    @NotBlank(message = "Description is required")
+    @Size(max = 255, message = "Description must be less than or equal to 255 characters")
+    private String description;
+}

--- a/services/main/src/main/java/org/retrade/main/model/entity/PlatformFeeTierEntity.java
+++ b/services/main/src/main/java/org/retrade/main/model/entity/PlatformFeeTierEntity.java
@@ -2,6 +2,8 @@ package org.retrade.main.model.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.*;
 import org.retrade.common.model.entity.BaseSQLEntity;
 
@@ -12,6 +14,13 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@Table(
+        name = "platform_fee_tiers",
+        indexes = {
+                @Index(name = "idx_min_price", columnList = "min_price"),
+                @Index(name = "idx_max_price", columnList = "max_price")
+        }
+)
 @Entity(name = "platform_fee_tiers")
 public class PlatformFeeTierEntity extends BaseSQLEntity {
     @Column(name = "min_price", nullable = false)

--- a/services/main/src/main/java/org/retrade/main/service/PlatformSettingService.java
+++ b/services/main/src/main/java/org/retrade/main/service/PlatformSettingService.java
@@ -2,6 +2,7 @@ package org.retrade.main.service;
 
 import org.retrade.common.model.dto.request.QueryWrapper;
 import org.retrade.common.model.dto.response.PaginationWrapper;
+import org.retrade.main.model.dto.request.PlatformFeeTierInsertRequest;
 import org.retrade.main.model.dto.response.PlatformFeeTierResponse;
 
 import java.math.BigDecimal;
@@ -15,6 +16,10 @@ public interface PlatformSettingService {
     boolean getBooleanValue(String key);
 
     BigDecimal findFeeRate(BigDecimal grandPrice);
+
+    PlatformFeeTierResponse upsertTier(PlatformFeeTierInsertRequest dto);
+
+    PlatformFeeTierResponse updateTier(String id, PlatformFeeTierInsertRequest dto);
 
     PaginationWrapper<List<PlatformFeeTierResponse>> getAllPlatformFeeTierConfig(QueryWrapper queryWrapper);
 }

--- a/services/main/src/main/java/org/retrade/main/service/impl/PlatformSettingServiceImpl.java
+++ b/services/main/src/main/java/org/retrade/main/service/impl/PlatformSettingServiceImpl.java
@@ -8,6 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.retrade.common.model.dto.request.QueryFieldWrapper;
 import org.retrade.common.model.dto.request.QueryWrapper;
 import org.retrade.common.model.dto.response.PaginationWrapper;
+import org.retrade.common.model.exception.ActionFailedException;
+import org.retrade.common.model.exception.ValidationException;
+import org.retrade.main.model.dto.request.PlatformFeeTierInsertRequest;
 import org.retrade.main.model.dto.response.PlatformFeeTierResponse;
 import org.retrade.main.model.entity.PlatformFeeTierEntity;
 import org.retrade.main.model.entity.PlatformSettingEntity;
@@ -16,13 +19,12 @@ import org.retrade.main.repository.jpa.PlatformSettingRepository;
 import org.retrade.main.service.PlatformSettingService;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -81,6 +83,47 @@ public class PlatformSettingServiceImpl implements PlatformSettingService {
         return platformFeeTierRepository.findMatchingFeeRate(grandPrice).orElse(BigDecimal.ZERO);
     }
 
+    @Transactional(rollbackFor = {ActionFailedException.class, ValidationException.class, Exception.class})
+    @Override
+    public PlatformFeeTierResponse upsertTier(PlatformFeeTierInsertRequest dto) {
+        validateTier(dto);
+
+        List<PlatformFeeTierEntity> tiers = platformFeeTierRepository.findAll(Sort.by("minPrice"));
+
+        PlatformFeeTierEntity newTier = PlatformFeeTierEntity.builder()
+                .minPrice(dto.getMinPrice())
+                .maxPrice(dto.getMaxPrice())
+                .feeRate(dto.getFeeRate())
+                .description(dto.getDescription())
+                .build();
+
+        tiers.add(newTier);
+
+        PlatformFeeTierEntity result = rebuildAndSaveTiers(tiers, newTier.getDescription(), null);
+        return wrapPlatformFeeTierResponse(result);
+    }
+
+    @Transactional(rollbackFor = {ActionFailedException.class, ValidationException.class, Exception.class})
+    @Override
+    public PlatformFeeTierResponse updateTier(String id, PlatformFeeTierInsertRequest dto) {
+        validateTier(dto);
+
+        List<PlatformFeeTierEntity> tiers = platformFeeTierRepository.findAll(Sort.by("minPrice"));
+
+        PlatformFeeTierEntity existing = tiers.stream()
+                .filter(t -> t.getId().equals(id))
+                .findFirst()
+                .orElseThrow(() -> new ValidationException("Tier with id " + id + " not found"));
+
+        existing.setMinPrice(dto.getMinPrice());
+        existing.setMaxPrice(dto.getMaxPrice());
+        existing.setFeeRate(dto.getFeeRate());
+        existing.setDescription(dto.getDescription());
+
+        PlatformFeeTierEntity result = rebuildAndSaveTiers(tiers, null, id);
+        return wrapPlatformFeeTierResponse(result);
+    }
+
     @Override
     public PaginationWrapper<List<PlatformFeeTierResponse>> getAllPlatformFeeTierConfig(QueryWrapper queryWrapper) {
         return platformFeeTierRepository.query(queryWrapper, (param) -> ((root, query, criteriaBuilder) -> {
@@ -111,5 +154,44 @@ public class PlatformSettingServiceImpl implements PlatformSettingService {
                 .feeRate(platformFeeTierEntity.getFeeRate())
                 .description(platformFeeTierEntity.getDescription())
                 .build();
+    }
+
+    private void validateTier(PlatformFeeTierInsertRequest dto) {
+        if (dto.getMinPrice().compareTo(BigDecimal.ZERO) < 0) {
+            throw new ValidationException("Min price cannot be negative");
+        }
+        if (dto.getMaxPrice() != null && dto.getMinPrice().compareTo(dto.getMaxPrice()) >= 0) {
+            throw new ValidationException("Min price must be less than max price");
+        }
+    }
+
+    private PlatformFeeTierEntity rebuildAndSaveTiers(List<PlatformFeeTierEntity> tiers,
+                                                      String insertedDescription,
+                                                      String updatedId) {
+        tiers.sort(Comparator.comparing(PlatformFeeTierEntity::getMinPrice));
+
+        BigDecimal lastMax = BigDecimal.ZERO;
+        for (PlatformFeeTierEntity t : tiers) {
+            t.setMinPrice(lastMax);
+            if (t.getMaxPrice() != null && t.getMaxPrice().compareTo(t.getMinPrice()) <= 0) {
+                throw new ValidationException("Invalid price range at tier: " + t.getDescription());
+            }
+            lastMax = (t.getMaxPrice() != null) ? t.getMaxPrice() : lastMax;
+        }
+
+        platformFeeTierRepository.deleteAllInBatch();
+        List<PlatformFeeTierEntity> saved = platformFeeTierRepository.saveAll(tiers);
+
+        if (insertedDescription != null) {
+            return saved.stream()
+                    .filter(t -> t.getDescription().equals(insertedDescription))
+                    .findFirst()
+                    .orElseThrow(() -> new ActionFailedException("Tier insert failed"));
+        } else {
+            return saved.stream()
+                    .filter(t -> t.getId().equals(updatedId))
+                    .findFirst()
+                    .orElseThrow(() -> new ActionFailedException("Tier update failed"));
+        }
     }
 }


### PR DESCRIPTION
- Introduced `insertPlatformFeeTierConfig` and `updatePlatformFeeTierConfig` endpoints in `PlatformSettingController` for managing fee tiers.
- Added `PlatformFeeTierInsertRequest` DTO for tier insertion and updates.
- Implemented `upsertTier` and `updateTier` methods in `PlatformSettingServiceImpl` with validation and transactional safety.
- Updated `PlatformFeeTierEntity` with indexed fields for optimized queries.